### PR TITLE
Added support for SUSE

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,7 +30,7 @@ default['timezone_iii']['localtime_path'] = '/etc/localtime'
 
 # Whether to use a symlink to tzdata (instead of copying).
 # Used only in the linux-default recipe.
-default['timezone_iii']['use_symlink'] = true
+default['timezone_iii']['use_symlink'] = false
 
 # Platform:            SUSE
 # Type:                string(-u,--utc,--localtime)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@
 
 # Use universal time if no other timezone is specified
 default['timezone_iii']['timezone'] = value_for_platform_family(
-  debian: 'Etc/UTC',
+  debian:  'Etc/UTC',
   default: 'UTC'
 )
 
@@ -30,4 +30,29 @@ default['timezone_iii']['localtime_path'] = '/etc/localtime'
 
 # Whether to use a symlink to tzdata (instead of copying).
 # Used only in the linux-default recipe.
-default['timezone_iii']['use_symlink'] = false
+default['timezone_iii']['use_symlink'] = true
+
+# Platform:            SUSE
+# Type:                string(-u,--utc,--localtime)
+# ServiceRestart:      boot.clock
+# Command:             /sbin/refresh_initrd
+#
+# Set to "-u" if your system clock is set to UTC, and to "--localtime"
+# if your clock runs that way.
+#
+default['timezone_iii']['hwclock'] = '--localtime'
+
+# Platform:            SUSE
+# Type:                yesno
+# Default:             yes
+# Description: Write back system time to the hardware clock
+
+# Is set to "yes" write back the system time to the hardware
+# clock at reboot or shutdown. Usefull if hardware clock is
+# much more inaccurate than system clock.  Set to "no" if
+# system time does it wrong due e.g. missed timer interrupts.
+# If set to "no" the hardware clock adjust feature is also
+# skipped because it is rather useless without writing back
+# the system time to the hardware clock.
+#
+default['timezone_iii']['systohc'] = 'yes'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'hemminger@hotmail.com'
 license 'Apache-2.0'
 description 'Configures the timezone for node'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.4'
+version '1.0.5'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
 # The `issues_url` points to the location where issues for this cookbook are

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,7 +19,7 @@ issues_url 'https://github.com/Stromweld/timezone_iii/issues'
 #
 source_url 'https://github.com/Stromweld/timezone_iii'
 
-%w(amazon centos debian fedora gentoo ubuntu pld redhat windows).each do |os|
+%w[amazon centos debian fedora gentoo ubuntu pld redhat suse windows].each do |os|
   supports os
 end
 

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -21,20 +21,19 @@
 
 TIMEZONE_FILE = '/etc/timezone'.freeze
 
-if File.file?('/etc/localtime') then
-  bash 'check-localtime' do
-    user 'root'
-    cwd '/tmp'
-    code <<-EOH
-    ls -la /etc/localtime >> /tmp/check.txt
-    if grep node['timezone_iii']['timezone'] /tmp/check.txt ; then
-      echo "Nothing to do!!!"
-    else
-      rm /etc/localtime
-    fi
-    rm /tmp/check.txt
-    EOH
-  end
+bash 'check-localtime' do
+  user 'root'
+  cwd '/tmp'
+  only_if { File.exist?('/etc/localtime') }
+  code <<-EOH
+  ls -la /etc/localtime >> /tmp/check.txt
+  if grep node['timezone_iii']['timezone'] /tmp/check.txt ; then
+    echo "Nothing to do!!!"
+  else
+    rm /etc/localtime
+  fi
+  rm /tmp/check.txt
+  EOH
 end
 
 template TIMEZONE_FILE do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,30 +17,35 @@
 # limitations under the License.
 
 case node['os']
-when 'linux'
-  package value_for_platform_family(
-    gentoo: 'timezone-data',
-    default: 'tzdata'
-  )
-  case node['platform_family']
-  when 'rhel', 'fedora'
-    include_recipe node['platform_version'].split('.')[0].to_i >= 7 ? 'timezone_iii::rhel7' : 'timezone_iii::rhel'
-  when 'debian', 'pld', 'amazon'
-    include_recipe "timezone_iii::#{node['platform_family']}"
-  else
-    # Load the generic Linux recipe if there's no better known way to change the
-    # timezone.  Log a warning (unless this is known to be the best way on a
-    # particular platform).
-    message = "Linux platform '#{node['platform']}' is unknown to this recipe; using generic Linux method"
-    log message do
-      level :warn
-      not_if { %w(centos gentoo rhel amazon).include? node['platform_family'] }
-      only_if { node['os'] == 'linux' }
+  when 'linux'
+    package value_for_platform_family(
+      gentoo:  'timezone-data',
+      suse:    'timezone',
+      default: 'tzdata'
+    )
+    case node['platform_family']
+      when 'suse'
+        include_recipe "timezone_iii::#{node['platform_family']}"
+      when 'rhel', 'fedora'
+        include_recipe node['platform_version'].split('.')[0].to_i >= 7 ? 'timezone_iii::rhel7' : 'timezone_iii::rhel'
+      when 'amazon'
+        include_recipe "timezone_iii::#{node['platform_family']}"
+      when 'debian', 'pld'
+        include_recipe "timezone_iii::#{node['platform_family']}"
+      else
+        # Load the generic Linux recipe if there's no better known way to change the
+        # timezone.  Log a warning (unless this is known to be the best way on a
+        # particular platform).
+        message = "Linux platform '#{node['platform']}' is unknown to this recipe; using generic Linux method"
+        log message do
+          level :warn
+          not_if { %w[centos gentoo rhel amazon].include? node['platform_family'] }
+          only_if { node['os'] == 'linux' }
+        end
+        include_recipe 'timezone_iii::linux_generic'
     end
-    include_recipe 'timezone_iii::linux_generic'
-  end
-when 'windows'
-  include_recipe 'timezone_iii::windows'
-else
-  raise 'OS Unsuported'
+  when 'windows'
+    include_recipe 'timezone_iii::windows'
+  else
+    raise 'OS Unsuported'
 end

--- a/recipes/suse.rb
+++ b/recipes/suse.rb
@@ -18,8 +18,10 @@
 
 # This sets the timezone on SUSE distributions
 
+v_major, v_minor = node['platform_version'].split(/\./)
+
 template '/etc/sysconfig/clock' do
-  source 'suse/clock.erb'
+  source v_major = 11 ? 'suse/clock.suse11.erb' : 'suse/clock.erb''
   owner 'root'
   group 'root'
   mode '0644'
@@ -30,3 +32,5 @@ execute 'tz-update' do
   command "/usr/sbin/zic -l #{node['timezone_iii']['timezone']}"
   action :nothing
 end
+
+

--- a/recipes/suse.rb
+++ b/recipes/suse.rb
@@ -19,10 +19,9 @@
 # This sets the timezone on SUSE distributions
 
 v_major, _v_minor = node['platform_version'].split(/\./)
-template_file = v_major.to_i == 11 ? 'suse/clock.suse11.erb' : 'suse/clock.erb'
 
 template '/etc/sysconfig/clock' do
-  source template_file
+  source v_major.to_i == 11 ? 'suse/clock.suse11.erb' : 'suse/clock.erb'
   owner 'root'
   group 'root'
   mode '0644'

--- a/recipes/suse.rb
+++ b/recipes/suse.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook:: timezone_iii
+# Recipe:: suse
+#
+# Copyright:: 2017, Siemens PLM Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This sets the timezone on SUSE distributions
+
+template '/etc/sysconfig/clock' do
+  source 'suse/clock.erb'
+  owner 'root'
+  group 'root'
+  mode '0644'
+  notifies :run, 'execute[tzdata-update]'
+end
+
+execute 'tzdata-update' do
+  command "/usr/sbin/zic -l #{node['timezone_iii']['timezone']}"
+  action :nothing
+end

--- a/recipes/suse.rb
+++ b/recipes/suse.rb
@@ -21,7 +21,7 @@
 v_major, _v_minor = node['platform_version'].split(/\./)
 
 template '/etc/sysconfig/clock' do
-  source v_major.to_i == 11 ? 'suse/clock.suse11.erb' : 'suse/clock.erb'
+  v_major.to_i == 11 ? source 'suse/clock.suse11.erb' : source 'suse/clock.erb'
   owner 'root'
   group 'root'
   mode '0644'

--- a/recipes/suse.rb
+++ b/recipes/suse.rb
@@ -18,10 +18,10 @@
 
 # This sets the timezone on SUSE distributions
 
-v_major, v_minor = node['platform_version'].split(/\./)
+v_major, _v_minor = node['platform_version'].split(/\./)
 
 template '/etc/sysconfig/clock' do
-  source v_major = 11 ? 'suse/clock.suse11.erb' : 'suse/clock.erb''
+  source v_major.to_i == 11 ? 'suse/clock.suse11.erb' : 'suse/clock.erb'
   owner 'root'
   group 'root'
   mode '0644'
@@ -32,5 +32,3 @@ execute 'tz-update' do
   command "/usr/sbin/zic -l #{node['timezone_iii']['timezone']}"
   action :nothing
 end
-
-

--- a/recipes/suse.rb
+++ b/recipes/suse.rb
@@ -2,7 +2,7 @@
 # Cookbook:: timezone_iii
 # Recipe:: suse
 #
-# Copyright:: 2017, Siemens PLM Software
+# Copyright:: 2017, Brad Beveridge
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ template '/etc/sysconfig/clock' do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :run, 'execute[tzdata-update]'
+  notifies :run, 'execute[tz-update]'
 end
 
-execute 'tzdata-update' do
+execute 'tz-update' do
   command "/usr/sbin/zic -l #{node['timezone_iii']['timezone']}"
   action :nothing
 end

--- a/recipes/suse.rb
+++ b/recipes/suse.rb
@@ -19,9 +19,10 @@
 # This sets the timezone on SUSE distributions
 
 v_major, _v_minor = node['platform_version'].split(/\./)
+template_file = v_major.to_i == 11 ? 'suse/clock.suse11.erb' : 'suse/clock.erb'
 
 template '/etc/sysconfig/clock' do
-  v_major.to_i == 11 ? source 'suse/clock.suse11.erb' : source 'suse/clock.erb'
+  source template_file
   owner 'root'
   group 'root'
   mode '0644'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 require 'spec_helper'
 
 describe 'timezone_iii::default' do

--- a/templates/default/suse/clock.erb
+++ b/templates/default/suse/clock.erb
@@ -1,4 +1,2 @@
-HWCLOCK="--localtime"
-SYSTOHC="yes"
 DEFAULT_TIMEZONE="US/Eastern"
 TIMEZONE="<%= node['timezone_iii']['timezone'] %>"

--- a/templates/default/suse/clock.erb
+++ b/templates/default/suse/clock.erb
@@ -1,0 +1,4 @@
+HWCLOCK="--localtime"
+SYSTOHC="yes"
+DEFAULT_TIMEZONE="US/Eastern"
+TIMEZONE="<%= node['timezone_iii']['timezone'] %>"

--- a/templates/default/suse/clock.suse11.erb
+++ b/templates/default/suse/clock.suse11.erb
@@ -1,0 +1,27 @@
+## Path:                System/Environment/Clock
+## Description:         Information about your timezone and time
+## Type:                string(-u,--utc,--localtime)
+## ServiceRestart:      boot.clock
+## Command:             /sbin/refresh_initrd
+#
+# Set to "-u" if your system clock is set to UTC, and to "--localtime"
+# if your clock runs that way.
+#
+HWCLOCK="<%= node['timezone_iii']['hwclock'] %>"
+
+## Type:                yesno
+## Default:             yes
+## Description: Write back system time to the hardware clock
+#
+# Is set to "yes" write back the system time to the hardware
+# clock at reboot or shutdown. Usefull if hardware clock is
+# much more inaccurate than system clock.  Set to "no" if
+# system time does it wrong due e.g. missed timer interrupts.
+# If set to "no" the hardware clock adjust feature is also
+# skipped because it is rather useless without writing back
+# the system time to the hardware clock.
+#
+SYSTOHC="<%= node['timezone_iii']['systohc'] %>"
+
+DEFAULT_TIMEZONE="US/Eastern"
+TIMEZONE="<%= node['timezone_iii']['timezone'] %>"


### PR DESCRIPTION
Hi, I have added support for SUSE platforms and also did some formatting fixes to make rubocop/foodcritic happy.  Did kitchen testing on centos 7.3, redhat 7.4, SUSE 12 and SUSE 11 sp4 in Chef 13.4.24 and Chef 12.21.12.  Very little difference to non-SUSE platforms.