### PR TITLE
Fix the variable interpolation in the Debian Bash mash

### DIFF
--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -27,7 +27,7 @@ if File.file?('/etc/localtime') then
     cwd '/tmp'
     code <<-EOH
     ls -la /etc/localtime >> /tmp/check.txt
-    if grep node['timezone_iii']['timezone'] /tmp/check.txt ; then
+    if grep #{node['timezone_iii']['timezone']} /tmp/check.txt ; then
       echo "Nothing to do!!!"
     else
       rm /etc/localtime


### PR DESCRIPTION
This prevents the follow up issue, as amended in #3. The variable interpolation was missing for the grep and thus the `/etc/localtime` was always deleted.

To get the fix working after the release, one needs to manually execute `dpkg-reconfigure -f noninteractive tzdata`, so the cookbook will pickup the changes again and work "idempotent".