### PR TITLE
Add clock_utc attribute to specify UTC config in /etc/sysconfig/clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It _should_ work with any OS that uses the IANA/Olson timezone database and stor
 | Attribute | Default | Comment |
 | -------------  | -------------  | -------------  |
 | ['timezone_iii']['timezone'] | 'value_for_platform_family(debian: 'Etc/UTC', default: 'UTC')' | String, timezone to set OS to |
+| ['timezone_iii']['clock_utc'] | `nil` | String(true,false), UTC setting in /etc/sysconfig/clock (RHEL family only) |
 | ['timezone_iii']['tzdata_dir'] | '/usr/share/zoneinfo' | String, the path to the root of the tzdata files; the default value is for most known distributions of Linux |
 | ['timezone_iii']['localtime_path'] | '/etc/localtime' | String, the path to the file used by the kernel to read the local timezone's settings; the default works for Linux and other *ix variants |
 | ['timezone_iii']['use_symlink'] | false | Boolean, whether to use a symlink into the tzdata tree rather than make a copy of the appropriate timezone data file (amazon and linux_generic recipes only) |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,12 @@ default['timezone_iii']['timezone'] = value_for_platform_family(
   default: 'UTC'
 )
 
+# Platform Family:     RHEL
+# Type:                string(true,false)
+
+# When 'true', write "UTC=true" line in /etc/sysconfig/clock.
+default['timezone_iii']['clock_utc'] = nil
+
 # Path to tzdata directory
 default['timezone_iii']['tzdata_dir'] = '/usr/share/zoneinfo'
 

--- a/templates/default/rhel/clock.erb
+++ b/templates/default/rhel/clock.erb
@@ -1,1 +1,4 @@
 ZONE="<%= node['timezone_iii']['timezone'] %>"
+<% unless node['timezone_iii']['clock_utc'].nil? -%>
+UTC=<%= node['timezone']['clock_utc'] %>
+<% end %>


### PR DESCRIPTION
Addresses https://github.com/Stromweld/timezone_iii/issues/9

Existing cookbook will have no change with this change, just adding capability to specify `UTC=`.