### PR TITLE
clean whyrun

### DIFF
--- a/recipes/linux_generic.rb
+++ b/recipes/linux_generic.rb
@@ -24,10 +24,9 @@ localtime_path = node['timezone_iii']['localtime_path']
 
 ruby_block 'confirm timezone' do
   block do
-    unless File.exist?(timezone_data_file)
-      raise "Can't find #{timezone_data_file}!"
-    end
+    raise "Can't find #{timezone_data_file}!"
   end
+  not_if { File.exist?(timezone_data_file) }
 end
 
 if node['timezone_iii']['use_symlink']

--- a/recipes/linux_generic.rb
+++ b/recipes/linux_generic.rb
@@ -34,7 +34,6 @@ if node['timezone_iii']['use_symlink']
     to timezone_data_file
     owner 'root'
     group 'root'
-    mode '0644'
   end
 
 else


### PR DESCRIPTION
I noticed some messages appears when chef-client run with `-W` (why-run)
```
eitest0001 Recipe: timezone_iii::linux_generic
eitest0001   * ruby_block[confirm timezone] action run[2017-12-06T23:39:41+09:00] INFO: Processing ruby_block[confirm timezone] action run (timezone_iii::linux_generic line 25)
eitest0001
eitest0001     - Would execute the ruby block confirm timezone
eitest0001   * link[/etc/localtime] action create[2017-12-06T23:39:41+09:00] INFO: Processing link[/etc/localtime] action create (timezone_iii::linux_generic line 34)
eitest0001
eitest0001     - Would change mode from '0777' to '0644'
```

I don't want cookbooks to "Would execute" when it's actually does nothing.
In these cases:
* the condition does not suffice, so raise shall not be invoked
* symlink's mode is always 0o777, so trying to change mode to 0o644 does nothing