### PR TITLE
Debian idempotency

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,7 +14,8 @@ verifier:
 
 platforms:
   - name: ubuntu-16.04
-  - name: centos-7.3
+  - name: centos-7.4
+  - name: centos-6.9
 
 suites:
   - name: default
@@ -24,3 +25,5 @@ suites:
       inspec_tests:
         - test/smoke/default
     attributes:
+      timezone_iii:
+        timezone: Turkey

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -27,8 +27,7 @@ file 'remove-wrong-localtime-link' do
   manage_symlink_source false
   only_if {
     File.exist?('/etc/localtime') &&
-      !File.symlink?('/etc/localtime') ||
-      !File.readlink('/etc/localtime').include?(node['timezone_iii']['timezone'])
+      File.read("/usr/share/zoneinfo/#{node['timezone_iii']['timezone']}") != File.read('/etc/localtime')
   }
 end
 

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -21,19 +21,15 @@
 
 TIMEZONE_FILE = '/etc/timezone'.freeze
 
-bash 'check-localtime' do
-  user 'root'
-  cwd '/tmp'
-  only_if { File.exist?('/etc/localtime') }
-  code <<-EOH
-  ls -la /etc/localtime >> /tmp/check.txt
-  if grep #{node['timezone_iii']['timezone']} /tmp/check.txt ; then
-    echo "Nothing to do!!!"
-  else
-    rm /etc/localtime
-  fi
-  rm /tmp/check.txt
-  EOH
+file 'remove-wrong-localtime-link' do
+  path '/etc/localtime'
+  action :delete
+  manage_symlink_source false
+  only_if {
+    File.exist?('/etc/localtime') &&
+      !File.symlink?('/etc/localtime') ||
+      !File.readlink('/etc/localtime').include?(node['timezone_iii']['timezone'])
+  }
 end
 
 template TIMEZONE_FILE do

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -16,3 +16,9 @@ end
 describe port(80), :skip do
   it { should_not be_listening }
 end
+
+describe command('date +%Z') do
+  its('exit_status') { should eq 0 }
+  its('stderr') { should eq '' }
+  its('stdout') { should eq "+03\n" }
+end

--- a/test/smoke/default/default_test.rb
+++ b/test/smoke/default/default_test.rb
@@ -1,4 +1,4 @@
-# # encoding: utf-8
+# encoding: utf-8
 
 # Inspec test for recipe timezone_iii::default
 


### PR DESCRIPTION
This PR addresses the issue comment in https://github.com/Stromweld/timezone_iii/issues/3#issuecomment-340434138 .
(Existing bash resource says "remove symlink if link path includes the desired time zone name", doesn't it?)

And the current test does almost nothing, so I added a very basic test.