### PR TITLE
RHEL7(w/ systemd) needs only timedatectl to change timezone

### DIFF
--- a/recipes/rhel7.rb
+++ b/recipes/rhel7.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook:: timezone_iii
-# Recipe:: amazon
+# Recipe:: rhel7
 #
 # Copyright:: 2017, Corey Hemminger
 #
@@ -19,19 +19,4 @@
 # This sets the timezone on EL 7 distributions (e.g. RedHat and CentOS)
 execute "timedatectl --no-ask-password set-timezone #{node['timezone_iii']['timezone']}" do
   not_if "timedatectl status | awk '/Time zone:/ {print $3}' | grep -w #{node['timezone_iii']['timezone']}"
-end
-
-template '/etc/sysconfig/clock' do
-  source 'rhel/clock.erb'
-  owner 'root'
-  group 'root'
-  mode '0644'
-  notifies :run, 'execute[tzdata-update]'
-end
-
-execute 'tzdata-update' do
-  command '/usr/sbin/tzdata-update'
-  action :nothing
-  # Amazon Linux doesn't have this command!
-  only_if { ::File.executable?('/usr/sbin/tzdata-update') }
 end


### PR DESCRIPTION
Found this RHEL7 recipe creates `/etc/sysconfig/clock` that has no meaning in RHEL7.
Just removed the unnecessary resources.