### PR TITLE
Ubuntu 18.04 Support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,7 @@ verifier:
   name: inspec
 
 platforms:
+  - name: ubuntu-18.04
   - name: ubuntu-16.04
   - name: centos-7.4
   - name: centos-6.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for timezone_iii
 
+## 1.1.7 (10/17/2018)
+
+- [iamjohnnym] - Added Ubuntu-18.04 into Kitchen
+
 ## 1.1.6 (12/30/2017)
 
 - [limitusus] - Removed unnecessary RHEL7 recipe resources

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'hemminger@hotmail.com'
 license 'Apache-2.0'
 description 'Configures the timezone for node'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.6'
+version '1.1.7'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 


### PR DESCRIPTION
Added support for Ubuntu 18.04 in the Kitchen so that those who want to use it, don't need to run tests to validate whether or not it works in 18.04.